### PR TITLE
Rescripts & Babel

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,20 @@
+{
+  "plugins": [
+    [
+      "module-resolver",
+      {
+        "root": [
+          "./src"
+        ],
+        "alias": {
+          "~components": "./src/app/components",
+          "~screens": "./src/app/screens",
+          "~assets": "./src/assets",
+          "~constants": "./src/constants",
+          "~scss": "./src/scss",
+          "~utils": "./src/utils"
+        }
+      }
+    ]
+  ]
+}

--- a/.rescriptsrc.js
+++ b/.rescriptsrc.js
@@ -1,0 +1,19 @@
+const babelLoaderMatcher = rule => rule.loader && rule.loader.includes('babel-loader');
+
+const oneOfFileLoaders = config => config.module.rules.find(rule => rule.oneOf).oneOf;
+
+const enableBabelRc = config => {
+  const fileLoaders = oneOfFileLoaders(config);
+  fileLoaders.forEach(loader => {
+    if (babelLoaderMatcher(loader)) {
+      loader.options.babelrc = true;
+    }
+  });
+}
+
+const customConfig = config => {
+  enableBabelRc(config);
+  return config;
+}
+
+module.exports = [customConfig];

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "baseUrl": ".",
+    "paths": {
+      "~components/*": ["./src/app/components/*"],
+      "~screens/*": ["./src/app/screens/*"],
+      "~assets/*": ["./src/assets/*"],
+      "~constants/*": ["./src/constants/*"],
+      "~scss/*": ["./src/scss/*"],
+      "~utils/*": ["./src/utils/*"]
+    }
+  },
+  "exclude": ["node_modules"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1175,6 +1175,188 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
+    "@rescripts/cli": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@rescripts/cli/-/cli-0.0.7.tgz",
+      "integrity": "sha512-BZOJaqeODSTIcEk6Gq5iSIB5tnx6nLb3BJ9oqkq2BRivylqlitW+fHAf+D7dkK6IQm9oIz0XNOtbCCSez+ag1Q==",
+      "dev": true,
+      "requires": {
+        "@rescripts/utilities": "^0.0.4",
+        "ramda": "^0.26.0",
+        "react-dev-utils": "^7.0.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+          "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.0.0"
+          }
+        },
+        "@rescripts/utilities": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/@rescripts/utilities/-/utilities-0.0.4.tgz",
+          "integrity": "sha512-JsdYzuzTvnisjEn2CEb1JgZ7d68vulUjZk5MDP4/t9QUm+wiS/CWVDxLjbji0uwjT/zOHmKJk5BL0Q6fQVfGyg==",
+          "dev": true,
+          "requires": {
+            "ramda": "^0.26.0"
+          }
+        },
+        "address": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/address/-/address-1.0.3.tgz",
+          "integrity": "sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg==",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "browserslist": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.4.1.tgz",
+          "integrity": "sha512-pEBxEXg7JwaakBXjATYw/D1YZh4QUSCX/Mnd/wnqSRPPSi1U39iDhDoKGoBUcraKdxDlrYqJxSI5nNvD+dWP2A==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30000929",
+            "electron-to-chromium": "^1.3.103",
+            "node-releases": "^1.1.3"
+          }
+        },
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "gzip-size": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.0.0.tgz",
+          "integrity": "sha512-5iI7omclyqrnWw4XbXAmGhPsABkSIDQonv2K0h61lybgofWa6iZyvrI3r2zsJH4P8Nb64fFVzlvfhs0g7BBxAA==",
+          "dev": true,
+          "requires": {
+            "duplexer": "^0.1.1",
+            "pify": "^3.0.0"
+          }
+        },
+        "inquirer": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.1.tgz",
+          "integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^3.0.0",
+            "figures": "^2.0.0",
+            "lodash": "^4.17.10",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rxjs": "^6.1.0",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^5.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "is-root": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-root/-/is-root-2.0.0.tgz",
+          "integrity": "sha512-F/pJIk8QD6OX5DNhRB7hWamLsUilmkDGho48KbgZ6xg/lmAZXHxzXQ91jzB3yRSw5kdQGGGc4yz8HYhTYIMWPg==",
+          "dev": true
+        },
+        "opn": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
+          "integrity": "sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==",
+          "dev": true,
+          "requires": {
+            "is-wsl": "^1.1.0"
+          }
+        },
+        "react-dev-utils": {
+          "version": "7.0.5",
+          "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-7.0.5.tgz",
+          "integrity": "sha512-zJnqqb0x6gd63E3xoz5pXAxBPNaW75Hyz7GgQp0qPhMroBCRQtRvG67AoTZZY1z4yCYVJQZAfQJFdnea0Ujbug==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0",
+            "address": "1.0.3",
+            "browserslist": "4.4.1",
+            "chalk": "2.4.2",
+            "cross-spawn": "6.0.5",
+            "detect-port-alt": "1.1.6",
+            "escape-string-regexp": "1.0.5",
+            "filesize": "3.6.1",
+            "find-up": "3.0.0",
+            "global-modules": "2.0.0",
+            "globby": "8.0.2",
+            "gzip-size": "5.0.0",
+            "immer": "1.10.0",
+            "inquirer": "6.2.1",
+            "is-root": "2.0.0",
+            "loader-utils": "1.2.3",
+            "opn": "5.4.0",
+            "pkg-up": "2.0.0",
+            "react-error-overlay": "^5.1.4",
+            "recursive-readdir": "2.2.2",
+            "shell-quote": "1.6.1",
+            "sockjs-client": "1.3.0",
+            "strip-ansi": "5.0.0",
+            "text-table": "0.2.0"
+          }
+        },
+        "react-error-overlay": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-5.1.6.tgz",
+          "integrity": "sha512-X1Y+0jR47ImDVr54Ab6V9eGk0Hnu7fVWGeHQSOXHf/C2pF9c6uy3gef8QUeuUiWlNb0i08InPSE5a/KJzNzw1Q==",
+          "dev": true
+        },
+        "shell-quote": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+          "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+          "dev": true,
+          "requires": {
+            "array-filter": "~0.0.0",
+            "array-map": "~0.0.0",
+            "array-reduce": "~0.0.0",
+            "jsonify": "~0.0.0"
+          }
+        },
+        "sockjs-client": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.3.0.tgz",
+          "integrity": "sha512-R9jxEzhnnrdxLCNln0xg5uGHqMnkhPSTzUZH2eXcR03S/On9Yvoq2wyUZILRUhZCNVu2PmwWVoyuiPz8th8zbg==",
+          "dev": true,
+          "requires": {
+            "debug": "^3.2.5",
+            "eventsource": "^1.0.7",
+            "faye-websocket": "~0.11.1",
+            "inherits": "^2.0.3",
+            "json3": "^3.3.2",
+            "url-parse": "^1.4.3"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.0.0"
+          }
+        }
+      }
+    },
     "@restart/context": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@restart/context/-/context-2.1.4.tgz",
@@ -1791,6 +1973,12 @@
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
     },
+    "array-filter": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+      "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
+      "dev": true
+    },
     "array-flatten": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
@@ -1804,6 +1992,18 @@
         "define-properties": "^1.1.2",
         "es-abstract": "^1.7.0"
       }
+    },
+    "array-map": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+      "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
+      "dev": true
+    },
+    "array-reduce": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+      "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
+      "dev": true
     },
     "array-union": {
       "version": "1.0.2",
@@ -2120,6 +2320,19 @@
         "@babel/runtime": "^7.4.2",
         "cosmiconfig": "^5.2.0",
         "resolve": "^1.10.0"
+      }
+    },
+    "babel-plugin-module-resolver": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.2.0.tgz",
+      "integrity": "sha512-tjR0GvSndzPew/Iayf4uICWZqjBwnlMWjSx6brryfQ81F9rxBVqwDJtFCV8oOs0+vJeefK9TmdZtkIFdFe1UnA==",
+      "dev": true,
+      "requires": {
+        "find-babel-config": "^1.1.0",
+        "glob": "^7.1.2",
+        "pkg-up": "^2.0.0",
+        "reselect": "^3.0.1",
+        "resolve": "^1.4.0"
       }
     },
     "babel-plugin-named-asset-import": {
@@ -2803,8 +3016,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -2822,13 +3034,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2841,18 +3051,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -2955,8 +3162,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -2966,7 +3172,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -2979,20 +3184,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3009,7 +3211,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3082,8 +3283,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3093,7 +3293,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3169,8 +3368,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3200,7 +3398,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3218,7 +3415,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3257,13 +3453,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -5511,6 +5705,24 @@
         }
       }
     },
+    "find-babel-config": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.2.0.tgz",
+      "integrity": "sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==",
+      "dev": true,
+      "requires": {
+        "json5": "^0.5.1",
+        "path-exists": "^3.0.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+          "dev": true
+        }
+      }
+    },
     "find-cache-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
@@ -6997,8 +7209,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -7022,7 +7233,6 @@
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -7035,8 +7245,7 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -7045,8 +7254,7 @@
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -7149,8 +7357,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -7160,7 +7367,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -7173,20 +7379,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -7203,7 +7406,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -7276,8 +7478,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -7287,7 +7488,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -7363,8 +7563,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -7394,7 +7593,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -7412,7 +7610,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -7451,13 +7648,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         }
@@ -10411,6 +10606,12 @@
         "performance-now": "^2.1.0"
       }
     },
+    "ramda": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
+      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==",
+      "dev": true
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -11082,6 +11283,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "reselect": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
+      "integrity": "sha1-79qpjqdFEyTQkrKyFjpqHXqaIUc=",
+      "dev": true
     },
     "resolve": {
       "version": "1.12.0",

--- a/package.json
+++ b/package.json
@@ -15,10 +15,9 @@
     "styled-components": "^4.4.0"
   },
   "scripts": {
-    "start": "PORT=3001 react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "start": "PORT=3001 rescripts start",
+    "build": "rescripts build",
+    "test": "rescripts test"
   },
   "eslintConfig": {
     "extends": "react-app"
@@ -34,5 +33,9 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@rescripts/cli": "0.0.7",
+    "babel-plugin-module-resolver": "^3.2.0"
   }
 }


### PR DESCRIPTION
## Resumen 

Agregue `rescript` para que podamos modificar webpack sin afectar la integridad del mismo. Basicamente lo que hace es tomar la configuración o `config` durante el building y permite usar una función o middleware para modificarla segun sea necesario. 

Esto lo necesito para activar  babel y usar imports absolutos en el proyecto. Dado que la app va a escalar y ya modifique el arbol de archivos, es conveniente que empecemos a usar imports absolutos para que las rutas sean mas sencillas. 

- `.babelrc` -> Configuración que utiliza el plugin module resolver para definir los path.
- `.rescriptsrc` -> Script para editar la configuración de webpack y habilitar babel. 
- `jsconfig` -> Archivo de configuración para poder acceder a las rutas absolutas en VSCode.

## Screenshot

![image](https://user-images.githubusercontent.com/36488701/70383085-9c5d8080-1946-11ea-9394-48ee94d86f3b.png)
